### PR TITLE
Fix agent module imports and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt pytest
-      - run: pytest tests/
+      - run: pytest -q

--- a/agent_tools.py
+++ b/agent_tools.py
@@ -1,17 +1,24 @@
 # agent_tools.py
-from llama_index.tools.tool_spec.base import BaseTool
+from llama_index.core.tools.types import BaseTool, ToolMetadata
 from github import Github
 import os
 import re
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 GITHUB_REPO = os.getenv("GITHUB_REPO")
-REPO = Github(GITHUB_TOKEN).get_repo(GITHUB_REPO)
+REPO = Github(GITHUB_TOKEN).get_repo(GITHUB_REPO) if GITHUB_TOKEN and GITHUB_REPO else None
 
 class FixPostTool(BaseTool):
     def __init__(self, pr_number: int):
-        super().__init__(name="FixPostTool", description="Fixes blog post content in the PR.")
         self.pr_number = pr_number
+        self._metadata = ToolMetadata(
+            name="FixPostTool",
+            description="Fixes blog post content in the PR."
+        )
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return self._metadata
 
     def __call__(self, file_name: str, new_content: str) -> str:
         pr = REPO.get_pull(self.pr_number)
@@ -23,12 +30,20 @@ class FixPostTool(BaseTool):
 
 class SuggestTitleTool(BaseTool):
     def __init__(self):
-        super().__init__(name="SuggestTitleTool", description="Suggests an improved title for a blog post.")
+        self._metadata = ToolMetadata(
+            name="SuggestTitleTool",
+            description="Suggests an improved title for a blog post."
+        )
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        return self._metadata
 
     def __call__(self, content: str) -> str:
         match = re.search(r"# (.+)", content)
         if not match:
             return "❌ No H1 title found."
         original = match.group(1)
-        suggestion = original.title().replace("And", "and").replace("Of", "of")  # Toy example
+        suggestion = original.title()
+        suggestion = re.sub(r"\b(And|Of|The|A|An)\b", lambda m: m.group(0).lower(), suggestion)
         return f"💡 Suggested title: {suggestion}"

--- a/agentic_blog_bot/agent_tools.py
+++ b/agentic_blog_bot/agent_tools.py
@@ -1,0 +1,7 @@
+"""Proxy module for backwards compatibility."""
+
+from importlib import import_module
+import sys
+
+_module = import_module("agent_tools")
+sys.modules[__name__] = _module

--- a/agentic_blog_bot/config.py
+++ b/agentic_blog_bot/config.py
@@ -1,0 +1,7 @@
+"""Proxy module for backwards compatibility."""
+
+from importlib import import_module
+import sys
+
+_module = import_module("config")
+sys.modules[__name__] = _module

--- a/agentic_blog_bot/github_utils.py
+++ b/agentic_blog_bot/github_utils.py
@@ -1,0 +1,7 @@
+"""Proxy module for backwards compatibility."""
+
+from importlib import import_module
+import sys
+
+_module = import_module("github_utils")
+sys.modules[__name__] = _module

--- a/agentic_blog_bot/linkedin_poster.py
+++ b/agentic_blog_bot/linkedin_poster.py
@@ -1,0 +1,7 @@
+"""Proxy module for backwards compatibility."""
+
+from importlib import import_module
+import sys
+
+_module = import_module("linkedin_poster")
+sys.modules[__name__] = _module

--- a/agentic_blog_bot/notifier.py
+++ b/agentic_blog_bot/notifier.py
@@ -1,0 +1,7 @@
+"""Proxy module for backwards compatibility."""
+
+from importlib import import_module
+import sys
+
+_module = import_module("notifier")
+sys.modules[__name__] = _module

--- a/github_utils.py
+++ b/github_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 GITHUB_REPO = os.getenv("GITHUB_REPO")  # e.g., "username/blog"
-REPO = Github(GITHUB_TOKEN).get_repo(GITHUB_REPO)
+REPO = Github(GITHUB_TOKEN).get_repo(GITHUB_REPO) if GITHUB_TOKEN and GITHUB_REPO else None
 
 PR_CONTEXT_FILE = "/tmp/last_pr.txt"
 


### PR DESCRIPTION
## Summary
- provide `agentic_blog_bot` compatibility package
- update `agent_tools` for new `llama_index` APIs and tweak title suggestion
- avoid GitHub auth errors when env vars missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815cad54e483209add3e1107c40104