### PR TITLE
Fix GPT naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # palm-tree
 Agentic Blog Draft System
 
-This is basically an attempt at "vibe coding" an agentic system that talks with me on Discord about updating my blog and cross-posting to LinkedIn whenever I have an interesting Chat with the GPT.
+This is basically an attempt at "vibe coding" an agentic system that talks with me on Discord about updating my blog and cross-posting to LinkedIn whenever I have an interesting chat with ChatGPT.
 


### PR DESCRIPTION
## Summary
- clarify a sentence in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agentic_blog_bot')*

------
https://chatgpt.com/codex/tasks/task_e_6881600be0388320ba9fe3fe8c07a065