### PR TITLE
Clarify tool initialization order

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ Agentic Blog Draft System
 
 This is basically an attempt at "vibe coding" an agentic system that talks with me on Discord about updating my blog and cross-posting to LinkedIn whenever I have an interesting Chat with the GPT.
 
+## Development notes
+
+`llama_agent.handle_pr_request` first builds a `VectorStoreIndex` from the PR
+contents. After the index is ready, the GitHub-focused tools are instantiated.
+These tools don't consume the index directly but operate on the pull request via
+the GitHub API. The index simply provides context for the language model during
+the agent run.
+

--- a/agent_tools.py
+++ b/agent_tools.py
@@ -1,34 +1,55 @@
 # agent_tools.py
-from llama_index.tools.tool_spec.base import BaseTool
+from llama_index.core.tools import BaseTool, ToolMetadata
 from github import Github
 import os
 import re
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 GITHUB_REPO = os.getenv("GITHUB_REPO")
-REPO = Github(GITHUB_TOKEN).get_repo(GITHUB_REPO)
+
+
+def get_repo():
+    """Return the GitHub repo object when needed.
+
+    Instantiating the repository lazily avoids side effects when this module is
+    imported in tests where no network access or credentials are available.
+    """
+    return Github(GITHUB_TOKEN).get_repo(GITHUB_REPO)
 
 class FixPostTool(BaseTool):
     def __init__(self, pr_number: int):
-        super().__init__(name="FixPostTool", description="Fixes blog post content in the PR.")
         self.pr_number = pr_number
 
+    @property
+    def metadata(self):
+        return ToolMetadata(name="FixPostTool", description="Fixes blog post content in the PR.")
+
     def __call__(self, file_name: str, new_content: str) -> str:
-        pr = REPO.get_pull(self.pr_number)
+        repo = get_repo()
+        pr = repo.get_pull(self.pr_number)
         branch = pr.head.ref
 
-        contents = REPO.get_contents(file_name, ref=branch)
-        REPO.update_file(contents.path, f"fix: updated {file_name}", new_content, contents.sha, branch=branch)
+        contents = repo.get_contents(file_name, ref=branch)
+        repo.update_file(contents.path, f"fix: updated {file_name}", new_content, contents.sha, branch=branch)
         return f"✅ Updated `{file_name}` in PR #{self.pr_number}"
 
 class SuggestTitleTool(BaseTool):
     def __init__(self):
-        super().__init__(name="SuggestTitleTool", description="Suggests an improved title for a blog post.")
+        pass
+
+    @property
+    def metadata(self):
+        return ToolMetadata(name="SuggestTitleTool", description="Suggests an improved title for a blog post.")
 
     def __call__(self, content: str) -> str:
         match = re.search(r"# (.+)", content)
         if not match:
             return "❌ No H1 title found."
         original = match.group(1)
-        suggestion = original.title().replace("And", "and").replace("Of", "of")  # Toy example
+        suggestion = (
+            original.title()
+            .replace("And", "and")
+            .replace("Of", "of")
+            .replace(" A ", " a ")
+        )  # Toy example to keep short articles lowercase
         return f"💡 Suggested title: {suggestion}"

--- a/github_utils.py
+++ b/github_utils.py
@@ -6,12 +6,20 @@ from pathlib import Path
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 GITHUB_REPO = os.getenv("GITHUB_REPO")  # e.g., "username/blog"
-REPO = Github(GITHUB_TOKEN).get_repo(GITHUB_REPO)
+
+
+def get_repo():
+    """Return the GitHub repo object only when it's actually needed.
+
+    This lazy initialization prevents network calls and credential errors during
+    import-time execution in tests.
+    """
+    return Github(GITHUB_TOKEN).get_repo(GITHUB_REPO)
 
 PR_CONTEXT_FILE = "/tmp/last_pr.txt"
 
 def get_pr_diff_and_comments(pr_number: int):
-    pr = REPO.get_pull(pr_number)
+    pr = get_repo().get_pull(pr_number)
     files = pr.get_files()
     comments = pr.get_review_comments()
 
@@ -42,7 +50,7 @@ def merge_pr_from_context():
     with open(PR_CONTEXT_FILE) as f:
         pr_number = int(f.read().strip())
 
-    pr = REPO.get_pull(pr_number)
+    pr = get_repo().get_pull(pr_number)
     if pr.is_merged():
         return f"🔁 PR #{pr_number} is already merged."
 

--- a/test_agent_tools.py
+++ b/test_agent_tools.py
@@ -1,4 +1,4 @@
-from agentic_blog_bot.agent_tools import SuggestTitleTool
+from agent_tools import SuggestTitleTool
 
 def test_title_suggestion():
     tool = SuggestTitleTool()

--- a/test_github_utils.py
+++ b/test_github_utils.py
@@ -1,4 +1,4 @@
-from agentic_blog_bot.github_utils import compute_diff_sha, should_skip_review, update_cached_sha
+from github_utils import compute_diff_sha, should_skip_review, update_cached_sha
 
 def test_compute_diff_sha_consistency():
     diff = "file.md:\n- old\n+ new"
@@ -13,7 +13,7 @@ def test_should_skip_review(tmp_path, monkeypatch):
     cache_file = tmp_path / "pr_shas.json"
     cache_file.write_text(f'{{"{pr_number}": "{test_sha}"}}')
 
-    monkeypatch.setattr("agentic_blog_bot.github_utils.PR_SHAS_FILE", cache_file)
+    monkeypatch.setattr("github_utils.PR_SHAS_FILE", cache_file)
 
     assert should_skip_review(pr_number, "abc123")
     assert not should_skip_review(pr_number, "xyz789")


### PR DESCRIPTION
## Summary
- remove invalid global agent and tool setup
- initialize tools after building the index
- provide comments linking tools and the index
- make GitHub helpers lazy to avoid side effects
- update tests for new imports and lazy modules
- document the initialization order for future maintainers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881600cc78c8320b91c47b541b7c0b9