### PR TITLE
style: apply Black formatting to Python files

### DIFF
--- a/authorship/chat_to_blog_agent.py
+++ b/authorship/chat_to_blog_agent.py
@@ -119,32 +119,24 @@ def extract_ideas_from_chat(chat: dict) -> List[str]:
         contents.append(f"{role}: {content}")
     transcript = "\n".join(contents)
 
-    prompt = [
-        HumanMessage(
-            content=f"""
+    prompt = [HumanMessage(content=f"""
         Analyze the following ChatGPT conversation and extract 3 distinct, interesting ideas that could form the basis of technical or reflective blog posts:
 
         {transcript}
-        """
-        )
-    ]
+        """)]
     response = llm(prompt)
     ideas = response.content.strip().split("\n")
     return [idea.strip("- ").strip() for idea in ideas if idea.strip()]
 
 
 def generate_blog_draft(idea: str) -> str:
-    prompt = [
-        HumanMessage(
-            content=f"""
+    prompt = [HumanMessage(content=f"""
         Write a detailed, informative blog post based on this idea:
 
         "{idea}"
 
         The blog post should include an engaging introduction, several structured sections, and a thoughtful conclusion. Aim for a professional yet conversational tone.
-        """
-        )
-    ]
+        """)]
     response = llm(prompt)
     return response.content.strip()
 

--- a/curation/check_auth.py
+++ b/curation/check_auth.py
@@ -11,11 +11,9 @@ async def is_login_valid() -> bool:
 
         try:
             await page.goto("https://chat.openai.com/")
-            result = await page.evaluate(
-                """() =>
+            result = await page.evaluate("""() =>
                 fetch("/api/auth/session").then(r => r.ok)
-            """
-            )
+            """)
         except Exception as e:
             print(f"Error during login check: {e}")
             return False

--- a/curation/download_chats.py
+++ b/curation/download_chats.py
@@ -33,25 +33,21 @@ async def fetch_chatgpt_chats():
 
         # Get token
         await page.goto("https://chat.openai.com/")
-        session = await page.evaluate(
-            """() => {
+        session = await page.evaluate("""() => {
             return fetch("/api/auth/session").then(r => r.json());
-        }"""
-        )
+        }""")
         token = session["accessToken"]
 
         # Fetch conversations
         headers = {"Authorization": f"Bearer {token}"}
         await page.goto(CHAT_LIST_URL, wait_until="networkidle")
-        response = await page.evaluate(
-            f"""() => {{
+        response = await page.evaluate(f"""() => {{
             return fetch("{CHAT_LIST_URL}", {{
                 headers: {{
                     Authorization: "Bearer {token}"
                 }}
             }}).then(r => r.json());
-        }}"""
-        )
+        }}""")
 
         for convo in response.get("items", []):
             cid = convo["id"]


### PR DESCRIPTION
### Motivation
- Enforce repository code style by running `black` to keep Python files consistent with project formatting rules.
- Make multiline string constructions more compact and consistent to reduce incidental diffs and improve readability.

### Description
- Reformatted `authorship/chat_to_blog_agent.py`, `curation/check_auth.py`, and `curation/download_chats.py` with `black` and adjusted multiline `HumanMessage(...)` and `page.evaluate(...)` constructs to inline triple-quoted strings.
- Kept behavior unchanged while simplifying the formatting of prompts and Playwright `evaluate` calls to a single-expression style.
- Removed stray `__pycache__` artifacts from the working tree.

### Testing
- Ran `black --check .` which succeeded after formatting changes.
- Ran `pytest -q` with `4 passed` and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f45c502c08320abfc51bfc7fd9659)