### PR TITLE
Validate PR context before merging and add unit test

### DIFF
--- a/publishing/github_utils.py
+++ b/publishing/github_utils.py
@@ -54,7 +54,12 @@ def merge_pr_from_context():
         return "❌ No prior PR context found."
 
     with open(PR_CONTEXT_FILE) as f:
-        pr_number = int(f.read().strip())
+        raw_pr_number = f.read().strip()
+
+    if not raw_pr_number.isdigit():
+        return "❌ PR context is invalid. Re-run review to store a valid PR number."
+
+    pr_number = int(raw_pr_number)
 
     pr = get_repo().get_pull(pr_number)
     if pr.is_merged():

--- a/publishing/test_github_utils.py
+++ b/publishing/test_github_utils.py
@@ -1,6 +1,7 @@
 from publishing.github_utils import (
     compute_diff_sha,
     get_repo,
+    merge_pr_from_context,
     save_pr_to_local,
     should_skip_review,
     update_cached_sha,
@@ -61,3 +62,13 @@ def test_save_pr_to_local_writes_expected_files(tmp_path, monkeypatch):
     assert (tmp_path / output_dir / "diff.md").exists()
     assert (tmp_path / output_dir / "comments.md").exists()
     assert context_path.read_text() == "7"
+
+
+def test_merge_pr_from_context_invalid_context_file(tmp_path, monkeypatch):
+    context_path = tmp_path / "last_pr.txt"
+    context_path.write_text("not-a-number")
+    monkeypatch.setattr("publishing.github_utils.PR_CONTEXT_FILE", str(context_path))
+
+    result = merge_pr_from_context()
+
+    assert "PR context is invalid" in result


### PR DESCRIPTION
### Motivation

- Prevent a crash and provide a clear error when the stored PR context is not a valid integer so `merge_pr_from_context` can fail gracefully.
- Cover the invalid-context behavior with an automated test.

### Description

- `merge_pr_from_context` now reads the raw context value, checks `raw_pr_number.isdigit()`, and returns an error message if the value is invalid before converting to `int`.
- Adjusted the `with open(PR_CONTEXT_FILE)` block so the numeric conversion happens after validation to avoid exceptions on bad data.
- Added `test_merge_pr_from_context_invalid_context_file` to `publishing/test_github_utils.py` and imported `merge_pr_from_context` in the test module.

### Testing

- Ran the `publishing/test_github_utils.py` unit tests including `test_merge_pr_from_context_invalid_context_file`, and they all passed.
- Ran the full publishing test module which includes `test_save_pr_to_local_writes_expected_files`, `test_get_repo_raises_when_unconfigured`, `test_update_cached_sha_roundtrip`, `test_should_skip_review`, and `test_compute_diff_sha_consistency`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fbbe96e588320900dca39266d8321)