### PR TITLE
Add CONTRIBUTING.md and link from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thanks for contributing to **palm-tree**.
+
+## Local development checks
+
+Run the following checks before opening a pull request:
+
+```bash
+black --check .
+pytest -q
+ruff check .
+mypy .
+```
+
+If `ruff` or `mypy` are not installed yet, install dev dependencies from the
+root requirements file:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Commit message format
+
+Use `type: summary`, for example:
+
+- `feat: add nightly review notifier`
+- `fix: handle missing github token`
+- `docs: clarify publishing setup`
+
+## Pull request checklist
+
+- Include a **Summary** section
+- Include a **Testing** section with command results
+- Keep changes focused and small when possible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,11 @@ ruff check .
 mypy .
 ```
 
-If `ruff` or `mypy` are not installed yet, install dev dependencies from the
-root requirements file:
+Install required tooling first (the root `requirements.txt` does **not** include
+`black`, `ruff`, or `mypy`):
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt black ruff mypy
 ```
 
 ## Commit message format

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ These tools don't consume the index directly but operate on the pull request via
 the GitHub API. The index simply provides context for the language model during
 the agent run.
 
+
+
+## Contributing
+
+See `CONTRIBUTING.md` for local quality checks and PR expectations.


### PR DESCRIPTION
### Motivation
- Add a CONTRIBUTING guide to document local development checks, commit message format, and PR checklist to improve contributor experience and standardize quality checks.

### Description
- Create `CONTRIBUTING.md` with recommended pre-PR commands (`black --check .`, `pytest -q`, `ruff check .`, `mypy .`), commit message examples, and a brief PR checklist, and add a `Contributing` section to `README.md` that links to `CONTRIBUTING.md`.

### Testing
- No automated tests were run as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151100d29c83209383dcbc9aaea3ac)